### PR TITLE
Deprecation warning: require rmagick instead of RMagick

### DIFF
--- a/lib/word/parts.rb
+++ b/lib/word/parts.rb
@@ -1,5 +1,5 @@
 require 'nokogiri' # docs at http://nokogiri.org
-require 'RMagick'  # docs at http://studio.imagemagick.org/RMagick/doc
+require 'rmagick'  # docs at http://studio.imagemagick.org/RMagick/doc
 require 'word/constants'
 require 'word/errors'
 require 'word/logger'


### PR DESCRIPTION
There is a deprecation warning using docx_builder gem:

`[DEPRECATION] requiring "RMagick" is deprecated. Use "rmagick" instead`

http://www.rubydoc.info/gems/rmagick/2.15.4#install